### PR TITLE
Add new podcast page to list of pages that should hide title

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -222,6 +222,7 @@ if (!function_exists('should_hide_title')) {
       'faq',
       'get connected',
       'media',
+      'podcast',
       'link tree',
       'ministries',
       'partnerships',


### PR DESCRIPTION
Making a dedicated page for this that we can link directly to. Based on the media page which I see hides its title via this method.